### PR TITLE
readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,19 +115,26 @@ In `package.json`:
   - `WordVocabularyPage.tsx` – manage words.
   - `TranslationPage.tsx` – English–Russian translation page.
 
-- **`components/`**: Reusable UI components.
-  - `common/` – shared UI (cards, dividers, loading spinner, theme provider, etc.).
-  - `learn/` – learning flow components (learning content, headers, word cards, etc.).
-  - `profile/` – profile, progress, daily goal, settings dialog.
-  - `word/` – dialogs and lists for word management.
+- **`src/`**: Main application code (logic, UI, data access).
+  - `components/` – reusable UI components.
+    - `common/` – shared UI (cards, dividers, loading spinner, theme provider, etc.).
+    - `learn/` – learning and practice flow components (learning cards, practice modes, error states, etc.).
+    - `profile/` – profile, progress, daily goal, FAQ, quotes, settings.
+    - `vocabulary/` – category and word lists, pickers, and edit dialogs.
+  - `hooks/` – domain-specific hooks (`useLearn`, `usePractice`, `useVocabulary`, `useTranslation`, `useUserData`, etc.).
+  - `store/` – Redux store configuration and slices.
+    - `index.ts` – creates the store and typed hooks.
+    - `slice/*Slice.ts` – slices for learning, practice, vocabulary, translation, and user data.
+  - `entity/` – core TypeScript types for categories, words, translations, and user data.
+  - `database/` – SQLite setup and migration runner (`db.ts`, `migrations.ts`).
+  - `service/` – domain services for categories, words, translations, user data, daily quote, and backup.
+  - `storage/` – helpers for persisting user-related settings and data.
+  - `mapper/` – mapping helpers between raw DB rows and entity types.
+  - `resources/` – constants and SQL schema (`resources/constants`, `resources/sql/schema.ts`).
+  - `util/` – generic helpers (e.g. date and string utilities).
 
-- **`store/`**: Redux store configuration and slices.
-  - `index.ts` – creates the store and typed hooks.
-  - `slice/*Slice.ts` – separate slices for learning, vocabulary, translation, and user data.
-
-- **`assets/`**: Static assets (images, fonts, animations, etc.).
-- **`resources/`**: Constants (layout spacing, dimensions, etc.).
-- **`util/`**: Utility functions and helpers.
+- **`assets/`**: Static assets (images, animations, and seed data in `assets/data/*`).
+- **`docs/`**: Project documentation (overview, architecture, learning flows, data model, and screenshots).
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Welcome to the documentation for **LearningEng** – an English vocabulary & tra
 - [Data model](./data-model.md)
 - [Screenshots & UI gallery](./screenshots.md)
 
+These documents are intended as a deeper dive into the current `app/` + `src/` structure described in the root `README.md`.
 Use this folder for any additional technical notes, design decisions, or guides that do not fit into the main `README.md`.
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,26 +5,31 @@ This document describes the high-level architecture of **LearningEng** and how t
 ### Top-level folders
 
 - **`app/`** – screens and navigation (Expo Router + React Navigation).
-- **`components/`** – reusable UI components grouped by domain (common, learn, profile, word).
-- **`hooks/`** – custom React hooks that encapsulate business logic and data access.
-- **`model/`** – data model, services, and storage (database + DTOs + mappers).
-- **`store/`** – Redux store configuration and slices for app state.
-- **`assets/`** – static assets (Lottie animations, data, etc.).
-- **`resources/`** – constants and SQL schema definition.
-- **`util/`** – generic helpers (e.g. date utilities).
+- **`src/components/`** – reusable UI components grouped by domain (`common`, `learn`, `profile`, `vocabulary`).
+- **`src/hooks/`** – custom React hooks that encapsulate business logic and data access.
+- **`src/store/`** – Redux store configuration and slices for app state.
+- **`src/entity/`** – core domain types (categories, words, translations, user data).
+- **`src/database/`** – SQLite setup and migrations.
+- **`src/service/`** – domain services (categories, words, translations, user data, daily quote, backup).
+- **`src/storage/`** – helpers for persisting user-related settings and data.
+- **`src/mapper/`** – mappers between raw DB rows and domain types.
+- **`src/resources/`** – constants and SQL schema definition.
+- **`src/util/`** – generic helpers (e.g. date utilities, string helpers).
+- **`assets/`** – static assets (Lottie animations, seed data, images, etc.).
+- **`docs/`** – project documentation.
 
 ### Data flow (simplified)
 
-1. **UI layer** (`app/`, `components/`) renders screens and controls.
-2. **Hooks** (`hooks/`) orchestrate data fetching and actions for specific domains.
-3. **Store** (`store/`) holds in-memory application state via Redux slices.
-4. **Model & services** (`model/`) talk to the database and other storage helpers.
-5. **Database** (`model/database/`, `resources/sql/`) persists vocabulary, user data, and related entities.
+1. **UI layer** (`app/`, `src/components/`) renders screens and controls.
+2. **Hooks** (`src/hooks/`) orchestrate data fetching and actions for specific domains.
+3. **Store** (`src/store/`) holds in-memory application state via Redux slices.
+4. **Domain & services** (`src/service/`, `src/storage/`, `src/mapper/`, `src/entity/`) talk to the database and other storage helpers.
+5. **Database** (`src/database/`, `src/resources/sql/`) persists vocabulary, user data, and related entities.
 
 ### Key modules
 
-- `model/service/*Service.ts` – business logic around categories, words, translation, and user data.
-- `store/slice/*Slice.ts` – state shape and reducers for each domain.
-- `hooks/useLearn.ts`, `useVocabulary.ts`, `useTranslation.ts` – glue between UI and data/model.
+- `src/service/*Service.ts` – business logic around categories, words, translations, user data, daily quote, and backup.
+- `src/store/slice/*Slice.ts` – state shape and reducers for each domain.
+- `src/hooks/useLearn.ts`, `src/hooks/usePractice.ts`, `src/hooks/useVocabulary.ts`, `src/hooks/useTranslation.ts`, `src/hooks/useUserData.ts` – glue between UI and data/domain layer.
 
 

--- a/docs/data-model.md
+++ b/docs/data-model.md
@@ -5,29 +5,42 @@ This document summarizes the main entities and how they are stored.
 ### Entities (conceptual)
 
 - **Category**
-  - Name
-  - Optional emoji/icon
+  - `id`
+  - `name`
+  - `type` (pre-loaded vs user-added)
+  - `icon` (emoji or icon name)
   - Relationship: has many **Words**
 - **Word**
-  - Text in English
-  - Translation (e.g. Russian)
-  - Category reference
-  - Metadata: created/updated at, maybe difficulty or status fields.
+  - `id`
+  - `word_en` (English text)
+  - `word_ru` (Russian text)
+  - `type` (pre-loaded vs user-added)
+  - `learned` flag
+  - `category` reference (via `category_id` in DB)
+  - `next_review` datetime
+  - `priority` (for scheduling / ordering)
+  - `text_example` (usage example)
 - **Translation**
-  - Source text
-  - Target text
-  - Direction (EN → RU or RU → EN)
-  - Timestamp, maybe favorite/flag fields.
+  - `id`
+  - `word_en`
+  - `word_ru`
+  - `translation_date` (timestamp of when the translation was made)
 - **User data**
-  - Daily goal
-  - Progress stats
-  - Other preferences.
+  - `name`
+  - `totalLearnedWords`
+  - `streak`
+  - `lastLearningDate`
+  - `reviewedToday`
+  - `learnedToday`
+  - `dailyGoal`
+  - `dailyGoalAchieve`
+  - `theme`
 
 ### Implementation references
 
-- `model/entity/types.ts` – TypeScript types for entities.
-- `model/database/db.ts` and `model/database/migrations.ts` – SQLite setup and migrations.
-- `resources/sql/schema.ts` – database schema definitions.
-- `model/service/*Service.ts` – how entities are created, updated, and queried.
+- `src/entity/types.ts` – TypeScript types for entities.
+- `src/database/db.ts` and `src/database/migrations.ts` – SQLite setup and migrations.
+- `src/resources/sql/schema.ts` – database schema definitions.
+- `src/service/*Service.ts` – how entities are created, updated, and queried.
 
 

--- a/docs/learning-flows.md
+++ b/docs/learning-flows.md
@@ -7,22 +7,27 @@ This document explains how the learning and review flows are structured from a p
 - **Daily goal** – target number of words to learn/review per day (configured on the profile screen).
 - **Learn session** – focuses on **new or less familiar** words.
 - **Review session** – focuses on **previously learned** words that need reinforcement.
+- **Practice modes** – additional training flows (e.g. word pairs, word building, overview) that reuse your vocabulary.
 
 ### High-level flow
 
 1. On app start, user data and settings are loaded (including daily goal).
-2. The **Learn** tab fetches from the store/model a set of words appropriate for:
+2. The **Learn & Review Words** tab fetches from the store/domain layer a set of words appropriate for:
    - **Learn mode** – new words that fit into the daily goal.
    - **Review mode** – words scheduled or available for review.
-3. When the user completes learning/reviewing a word:
-   - Progress is updated (both in Redux state and persisted storage).
+   - **Practice modes** – custom practice sets built from your chosen category and filters.
+3. When the user completes learning/reviewing/practicing a word:
+   - Progress is updated (both in Redux state and persisted storage, where applicable).
    - The next word in the queue is shown, or the session ends when the set is exhausted.
 
 ### Implementation hints
 
 - Look into:
-  - `hooks/useLearn.ts` – orchestration logic for learn/review.
-  - `store/slice/learnSlice.ts` – state and reducers related to learning sessions.
-  - `components/learn/*` – UI for cards, headers, and error/empty states.
+  - `src/hooks/useLearn.ts` – orchestration logic for daily learn/review sets.
+  - `src/hooks/usePractice.ts` – logic for practice sets and filters.
+  - `src/store/slice/learnSlice.ts` – state and reducers related to daily learning sessions.
+  - `src/store/slice/practiceSlice.ts` – state and reducers related to practice flows.
+  - `src/components/learn/learning/*` – UI for the main learning flow.
+  - `src/components/learn/practice/*` – UI for practice modes (modes, settings, wrapper).
 
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -10,11 +10,13 @@ This document gives a high-level overview aimed at new contributors or future-yo
 - Offer **daily learning and review** sessions so words are seen repeatedly over time.
 - Include a **built-in translation helper** (English ↔ Russian) tightly integrated with your personal vocabulary.
 
+The app is structured around three main tabs: **Vocabulary**, **Learn & Review Words**, and **Profile**.
+
 ### Core concepts
 
 - **User profile & progress** – daily goal, streaks, and progress cards.
-- **Vocabulary** – categories and words you add and manage.
-- **Learning flows** – sessions that pick a subset of words for learning/review.
+- **Vocabulary** – categories and words you add and manage, plus quick access to the translation helper.
+- **Learning & practice flows** – daily sets and practice modes that pick a subset of words for learning/review.
 - **Translation helper** – quick lookup with history and ability to add useful translations to your vocabulary.
 
 

--- a/docs/screenshots.md
+++ b/docs/screenshots.md
@@ -6,10 +6,10 @@ Use this document to showcase the most important screens of **LearningEng**.
 
 - **Dashboard / Profile**
   - Daily goal, progress cards, and quick access to settings.
-- **Learn tab**
+- **Learn & Review Words tab**
   - Learning card UI with a word, translation, and actions.
-- **Review tab/flow**
-  - Example of reviewing previously learned words.
+  - Review flow for previously learned words.
+  - Optional practice modes (e.g. word pairs, word building) if you want to showcase them.
 - **Vocabulary tab**
   - Category list screen.
   - Word list screen with add/edit dialogs.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Expands and reorganizes documentation to reflect the current codebase and learning flows.
> 
> - Updates root `README.md` with a `src/`-centric project structure, clarifies components/hooks/store/services/entities, and links to new docs
> - Adds `docs/` with `overview.md`, `architecture.md`, `learning-flows.md`, `data-model.md`, `screenshots.md`, and an index `README.md`
> - Documents data flow between `app/`, `src/components`, `src/hooks`, `src/store`, `src/service`, and `src/database`
> - Details entities and schema fields in `src/entity` and `src/resources/sql`, including practice-related concepts
> - Describes learn/review/practice flows and where to find related hooks, slices, and components